### PR TITLE
Allow global angular in non-browserify environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ $scope.elmTodoSetupPorts = function (ports) {
   ports="elmTodoSetupPorts(ports)">
 </elm-component>
 ```
+
+### Releases
+
+* 0.2.0 - Add support for global `angular` in non-browserify (`require`) environments.

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
-var angular = require('angular');
+(function angularElmComponents(angular) {
+   angular.module('angularElmComponents', [])
+       .directive('elmComponent', function () {
+           return {
+               template: '<div></div>',
+               scope: {
+                   src: '=',
+                   flags: '=',
+                   ports: '&'
+               },
+               link: function (scope, element) {
+                   var app = scope.src.embed(element[0], scope.flags);
 
-angular.module('angularElmComponents', [])
-    .directive('elmComponent', function () {
-        return {
-            template: '<div></div>',
-            scope: {
-                src: '=',
-                flags: '=',
-                ports: '&'
-            },
-            link: function (scope, element) {
-                var app = scope.src.embed(element[0], scope.flags);
-
-                if (scope.ports !== undefined) {
-                    scope.ports({ ports: app.ports });
-                }
-            }
-        };
-    });
+                   if (scope.ports !== undefined) {
+                       scope.ports({ ports: app.ports });
+                   }
+               }
+           };
+       });
+})(angular || require('angular'));


### PR DESCRIPTION
Allow global `angular` in non-browserify/RequireJS environment by wrapping in an IIFE and short-circuiting on the global.

I went ahead and updated the README with the expected release info. I can remove that if it's overzealous.

A more thorough solution would be to create a [UMD](https://github.com/umdjs/umd) but I didn't need it. This change should make it easier to go that route if someone needs that support.

Fixes #1.