### PR TITLE
Upgrade to Elm 0.19 and option for a `$destroy` clean-up function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $scope.elmTodoComponent = require('../../dist/elm/todomvc.js').Todo;
 In order to give your elm app some flags on startup to initialize its state, use the `flags` attribute on the `elm-component` directive. It takes an object:
 
 ```js
-// app/componenets/example_controller.js
+// app/components/example_controller.js
 $scope.elmTodoComponent = require('../../dist/elm/todomvc.js').Todo;
 $scope.elmTodoFlags = { todos: ['Get Milk', 'Do Laundry'] };
 ```
@@ -53,7 +53,7 @@ These flags give you the flexibility to set up an initial state in Javascript fi
 Changes to the `flags` attribute after the Elm component has been initialized will **not** affect the component in any way. In order to interop between your Javascript and Elm, use `ports` instead. Ports allow your Javascript to send values to, and subscribe to values from, your Elm component.
 
 ```js
-// app/componenets/example_controller.js
+// app/components/example_controller.js
 $scope.elmTodoComponent = require('../../dist/elm/todomvc.js').Todo;
 $scope.elmTodoFlags = { todos: ['Get Milk', 'Do Laundry'] };
 $scope.elmTodoSetupPorts = function (ports) {
@@ -86,4 +86,5 @@ $scope.elmTodoSetupPorts = function (ports) {
 
 ### Releases
 
+* 0.3.0 - Add support for Elm 0.19 and a `$destroy` clean-up function.
 * 0.2.0 - Add support for global `angular` in non-browserify (`require`) environments.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ $scope.elmTodoSetupPorts = function (ports) {
 
     ports.todos.send('Invent the Universe');
     ports.todos.send('Bake an Apple Pie');
+
+    var deregisterTodoAdded = $rootScope.$on('todoAdded', function todoAdded(todoItem) {
+        ports.todos.send(todoItem);
+    });
+
+    // If there are things to clean up, return a function that cleans them up.
+    return function cleanUp() {
+        deregisterTodoAdded();
+    };
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,20 +1,27 @@
 (function angularElmComponents(angular) {
-   angular.module('angularElmComponents', [])
-       .directive('elmComponent', function () {
-           return {
-               template: '<div></div>',
-               scope: {
-                   src: '=',
-                   flags: '=',
-                   ports: '&'
-               },
-               link: function (scope, element) {
-                   var app = scope.src.embed(element[0], scope.flags);
+    angular.module('angularElmComponents', [])
+        .directive('elmComponent', function () {
+            return {
+                template: '<div></div>',
+                scope: {
+                    src: '=',
+                    flags: '=',
+                    ports: '&'
+                },
+                link: function (scope, element) {
+                    var app = scope.src.embed(element[0], scope.flags);
+                    var cleanUp = angular.noop;
 
-                   if (scope.ports !== undefined) {
-                       scope.ports({ ports: app.ports });
-                   }
-               }
-           };
-       });
+                    if (scope.ports !== undefined) {
+                        cleanUp = scope.ports({ ports: app.ports });
+                    }
+
+                    scope.$on('$destroy', function cleanUpPorts() {
+                        if (angular.isFunction(cleanUp)) {
+                            cleanUp();
+                        }
+                    });
+                }
+            };
+        });
 })(angular || require('angular'));

--- a/index.js
+++ b/index.js
@@ -9,8 +9,19 @@
                     ports: '&'
                 },
                 link: function (scope, element) {
-                    var app = scope.src.embed(element[0], scope.flags);
+                    var app = {};
                     var cleanUp = angular.noop;
+                    var isElm0_19 = scope.src.init !== undefined;
+
+                    if (isElm0_19) {
+                        app = scope.src.init({
+                            node: element[0],
+                            flags: scope.flags
+                        });
+                    }
+                    else { // Elm 0.18 or lower.
+                        app = scope.src.embed(element[0], scope.flags);
+                    }
 
                     if (scope.ports !== undefined) {
                         cleanUp = scope.ports({ ports: app.ports });


### PR DESCRIPTION
I have added two additional features:
* Elm 0.19 support
* The ability to clean up/unregister handlers when the component scope is destroyed

If you'd rather I can make these two separate pull requests.

Thanks!